### PR TITLE
fix: unbreak npm publish flow and add CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: bun install
+        run: bun install
+
+      - name: bun test
+        run: bun test
+
+      - name: bun run build:schema
+        run: bun run build:schema
+
+      - name: ensure schema is up to date
+        run: |
+          if ! git diff --quiet -- schemas/; then
+            echo "::error::schemas/ is out of date. Run 'bun run build:schema' and commit the result."
+            git diff -- schemas/
+            exit 1
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,15 +15,42 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
       - name: bun install
         run: bun install
 
       - name: bun test
         run: bun test
 
-      - name: npm publish
+      - name: bun run build:schema
+        run: bun run build:schema
+
+      - name: verify tag matches package.json version
         run: |
-          printf "//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n" > "$HOME/.npmrc"
-          npm publish
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
+          echo "publishing version $PKG_VERSION"
+
+      - name: verify version not already on npm
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          EXISTING=$(npm view "${PKG_NAME}@${PKG_VERSION}" version 2>/dev/null || true)
+          if [ -n "$EXISTING" ]; then
+            echo "::error::${PKG_NAME}@${PKG_VERSION} is already published. Bump the version in package.json and re-tag."
+            exit 1
+          fi
+
+      - name: npm publish
+        run: npm publish --access public
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - "v*"
 
+# id-token: write is required for npm trusted publishing (OIDC).
+# contents: read is the default minimum after id-token is requested.
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -15,11 +21,15 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
+      # Node 22.14+ and npm 11.5.1+ are required for npm trusted publishing.
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22.14"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm CLI for trusted publishing
+        run: npm install --global npm@latest
 
       - name: bun install
         run: bun install
@@ -50,6 +60,13 @@ jobs:
             exit 1
           fi
 
+      # The npm CLI auto-detects the GitHub Actions OIDC environment and
+      # exchanges the OIDC token for a short-lived publish token when a
+      # trusted publisher is configured for this package on npmjs.com.
+      # If trusted publishing is not yet configured (e.g. the bootstrap
+      # publish), the CLI falls back to NODE_AUTH_TOKEN. Once trusted
+      # publishing is live and "disallow tokens" is enabled on npmjs.com,
+      # the NPM_TOKEN secret can be removed entirely.
       - name: npm publish
         run: npm publish --access public
         env:

--- a/README.md
+++ b/README.md
@@ -199,7 +199,18 @@ It does not remove:
 
 ## Upgrading
 
-Re-run `bunx opencode-hero-workflow@latest init --migrate` to pull in new defaults from a compatible release without overwriting files you have customised. The scaffolder uses a SHA-256 content-hash manifest to detect drift and refuses to clobber edited files; pass `--force` only when you have reviewed the diff and want to reset. If you prefer pinned installs, use an explicit package version (for example `bunx opencode-hero-workflow@0.2.0 init`). Major-version bumps may require a manual migration step; consult the CHANGELOG for the target version once one exists.
+Re-run `bunx opencode-hero-workflow@latest init --migrate` to pull in new defaults from a compatible release without overwriting files you have customised. The scaffolder uses a SHA-256 content-hash manifest to detect drift and refuses to clobber edited files; pass `--force` only when you have reviewed the diff and want to reset. If you prefer pinned installs, use an explicit package version (for example `bunx opencode-hero-workflow@0.2.1 init`). Major-version bumps may require a manual migration step; consult the CHANGELOG for the target version once one exists.
+
+### Cutting a release (maintainers)
+
+Releases are published to npm by a tag-driven GitHub Actions workflow (`.github/workflows/publish.yml`). To cut one:
+
+1. Bump `version` in `package.json` and merge to `main`.
+2. Wait for the `CI` workflow on `main` to go green (it runs `bun test` and `bun run build:schema`).
+3. Tag and push: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+4. Watch the `Publish` workflow. It re-runs the tests, verifies the tag matches `package.json`, refuses to re-publish a version already on npm, then runs `npm publish --access public`.
+
+If a publish fails after the tag is pushed, fix the underlying issue, bump to the next patch version, and tag again. Do not force-push tags or attempt to re-publish the same version — the guard in the workflow will reject it.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,23 @@ Releases are published to npm by a tag-driven GitHub Actions workflow (`.github/
 
 If a publish fails after the tag is pushed, fix the underlying issue, bump to the next patch version, and tag again. Do not force-push tags or attempt to re-publish the same version — the guard in the workflow will reject it.
 
+#### Authentication: trusted publishing (preferred) vs. token (bootstrap)
+
+The publish workflow is configured to support npm [trusted publishing](https://docs.npmjs.com/trusted-publishers) via OIDC. With trusted publishing, the CI run authenticates to npm using a short-lived OIDC token issued by GitHub Actions — no long-lived `NPM_TOKEN` secret is needed and provenance attestations are generated automatically.
+
+Trusted publishing must be configured per-package on npmjs.com, which means the **first** publish of a package has to use a token. The bootstrap procedure is:
+
+1. **Bootstrap publish (one-time, with token).** Set the `NPM_TOKEN` repo secret to a publish-capable Automation token, then push a `v*` tag. The workflow falls back to `NODE_AUTH_TOKEN` because no trusted publisher is registered yet.
+2. **Configure trusted publishing.** On npmjs.com → your package → Settings → Trusted Publisher, choose GitHub Actions and fill in:
+   - Organization or user: `arikru`
+   - Repository: `opencode-hero-workflow`
+   - Workflow filename: `publish.yml`
+   - Environment name: leave blank (we don't use a deployment environment).
+3. **Verify.** Push the next `v*` tag. The workflow log should show `npm` exchanging an OIDC token instead of using `NODE_AUTH_TOKEN`. The published version on npmjs.com will display a "Provenance" badge.
+4. **Lock down tokens (recommended).** On npmjs.com → your package → Settings → Publishing access, choose **"Require two-factor authentication and disallow tokens"**. Then revoke the bootstrap `NPM_TOKEN` and delete the `NPM_TOKEN` GitHub secret.
+
+The workflow keeps `NODE_AUTH_TOKEN` wired up so that step 1 works without changes, and so an emergency manual republish is still possible if trusted publishing is ever disabled.
+
 ## Contributing
 
 The package is developed using its own workflow. The day-shift slash commands work in this repo (`/grill`, `/prd`, `/kanban`, `/tdd`, `/verify`, `/review`), and `/ralph` is available if you set `sandcastle.enabled: true` in your local `.hero/config.jsonc`. Pull requests welcome through the standard GitHub PR flow.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-hero-workflow",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "OpenCode workflow scaffold encoding Matt Pocock's Essential Skills for AI Coding.",
   "repository": {
@@ -15,6 +15,9 @@
     "scaffold"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "hero-init": "./bin/init.js"
   },

--- a/tests/readme.test.ts
+++ b/tests/readme.test.ts
@@ -61,13 +61,17 @@ describe("README.md", () => {
 
   test("contains a fenced code block with the bunx install one-liner", () => {
     const body = readReadme();
-    // Find every fenced code block and check at least one carries both tokens.
+    // Find every fenced code block and check at least one carries an
+    // install one-liner. We accept either the npm form
+    // (`bunx opencode-hero-workflow[@version] init`) or the GitHub form
+    // (`bunx github:owner/repo[#ref] init`) so README authors can switch
+    // between distribution channels without breaking the structural guard.
     const blocks = body.split(/```/);
     // Even-indexed entries are outside fences; odd-indexed are inside.
     const fenced = blocks.filter((_, idx) => idx % 2 === 1);
-    const hasInstall = fenced.some(
-      (block) => block.includes("bunx github:") && block.includes("init"),
-    );
+    const installPattern =
+      /bunx\s+(opencode-hero-workflow(@[^\s]+)?|github:[^\s]+)\s+[^\n`]*\binit\b/;
+    const hasInstall = fenced.some((block) => installPattern.test(block));
     expect(hasInstall).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

- Fixes the silent failure that caused `v0.2.0` to never reach npm, so `bunx opencode-hero-workflow@latest init` currently 404s.
- Adds a `CI` workflow so README/test drift fails the PR instead of the tag publish.
- Hardens `publish.yml` with version guards and proper npm auth.

## Root cause

Commit `8c8e987` (v0.2.0 README rewrite) switched the install one-liner from the GitHub form (`bunx github:arikru/opencode-hero-workflow#vX.Y.Z init`) to the npm form (`bunx opencode-hero-workflow@latest init`), but did not update `tests/readme.test.ts:62-72`, which still required the literal substring `"bunx github:"` in some fenced block. Because `publish.yml` runs `bun test` before `npm publish`, the failing test short-circuited the release on the `v0.2.0` tag push. The package was never published, but the failure surfaced only as a red dot on the tag — no PR gate would have caught it because there was no CI workflow.

## Changes

| File | Change |
|------|--------|
| `tests/readme.test.ts` | Broaden the install assertion to accept either npm form (`bunx opencode-hero-workflow[@ver] init`) or GitHub form (`bunx github:owner/repo[#ref] init`). Keeps the structural guard, allows future channel switches without silent breakage. |
| `.github/workflows/ci.yml` (new) | Runs `bun test` and `bun run build:schema` on PRs and `main` pushes. Fails if `schemas/` drifts from what `build:schema` produces. Uses concurrency to cancel duplicate runs. |
| `.github/workflows/publish.yml` | Added `setup-node` with `registry-url` so publish uses `NODE_AUTH_TOKEN` instead of hand-written `.npmrc`. Added `bun run build:schema` before publish. Added a tag↔`package.json` version match guard and a "version-not-on-npm" guard. Switched to `npm publish --access public`. |
| `package.json` | Bump `0.2.0` → `0.2.1` (the `v0.2.0` tag is consumed by the failed publish run; rolling forward avoids force-pushing a tag). Added `publishConfig.access: public`. |
| `README.md` | Update pinned-version example to `0.2.1`; add a "Cutting a release (maintainers)" subsection documenting the tag-driven flow and that re-publishing a version is rejected by the workflow guard. |

## Verification

- `bun test`: 197/197 pass locally (the previously failing README test now passes against the npm-form install line).
- `bun run build:schema`: produces no diff against the committed `schemas/hero-schema.json`.
- `npm pack --dry-run`: clean 0.2.1 tarball, 64 files, all expected directories included (`bin/`, `plugin/`, `scripts/`, `sandcastle/`, `templates/`, `schemas/`).

## Release procedure after merge

1. Confirm `CI` is green on `main`.
2. `git tag v0.2.1 && git push origin v0.2.1`.
3. Watch the `Publish` workflow. It will re-run tests, verify `v0.2.1` matches `package.json`, confirm the version is not already on npm, then publish.
4. Smoke test: `bunx opencode-hero-workflow@latest init` from a scratch directory.

Requires the `NPM_TOKEN` repo secret to be a publish-capable automation token (the existing workflow already referenced this secret; if it isn't set, the publish step will fail with an auth error after the guards pass).