### PR TITLE
fix: write hero:* commands as objects to match opencode schema

### DIFF
--- a/bin/init.js
+++ b/bin/init.js
@@ -30,14 +30,37 @@ const MODEL_ROLES = /** @type {const} */ ([
   { key: "planner", label: "Planner", example: "github-copilot/claude-sonnet-4.5" },
 ]);
 
+// Each entry follows the opencode commands schema: an object with at minimum a
+// `template` field (the prompt sent to the LLM). See https://opencode.ai/docs/commands/
 const GLOBAL_HERO_COMMANDS = /** @type {const} */ ({
-  "hero:grill-me": "Load the `hero-grill` skill and start an alignment session on the user-provided topic.",
-  "hero:tdd-loop": "Load the `hero-tdd-loop` skill and run a red-green-refactor loop for the selected GitHub issue.",
-  "hero:kanban": "Load the `hero-kanban` skill and break the current plan or PRD into vertical-slice GitHub issues.",
-  "hero:improve-architecture": "Load the `hero-improve-architecture` skill and scan the codebase for deepening opportunities.",
-  "hero:reviewer-standards": "Load the `hero-reviewer-standards` skill and audit the diff with push-style review standards.",
-  "hero:dogfood": "Load the `hero-dogfood` skill and run a happy-path to adversarial dogfooding session.",
-  "hero:to-prd": "Load the `hero-to-prd` skill and turn the current context into a PRD GitHub issue.",
+  "hero:grill-me": {
+    description: "Start a hero-grill alignment session on the user-provided topic.",
+    template: "Load the `hero-grill` skill and start an alignment session on the user-provided topic.",
+  },
+  "hero:tdd-loop": {
+    description: "Run a red-green-refactor loop for the selected GitHub issue.",
+    template: "Load the `hero-tdd-loop` skill and run a red-green-refactor loop for the selected GitHub issue.",
+  },
+  "hero:kanban": {
+    description: "Break the current plan or PRD into vertical-slice GitHub issues.",
+    template: "Load the `hero-kanban` skill and break the current plan or PRD into vertical-slice GitHub issues.",
+  },
+  "hero:improve-architecture": {
+    description: "Scan the codebase for architectural deepening opportunities.",
+    template: "Load the `hero-improve-architecture` skill and scan the codebase for deepening opportunities.",
+  },
+  "hero:reviewer-standards": {
+    description: "Audit the diff with push-style review standards.",
+    template: "Load the `hero-reviewer-standards` skill and audit the diff with push-style review standards.",
+  },
+  "hero:dogfood": {
+    description: "Run a happy-path to adversarial dogfooding session.",
+    template: "Load the `hero-dogfood` skill and run a happy-path to adversarial dogfooding session.",
+  },
+  "hero:to-prd": {
+    description: "Turn the current context into a PRD GitHub issue.",
+    template: "Load the `hero-to-prd` skill and turn the current context into a PRD GitHub issue.",
+  },
 });
 
 async function readPackageVersion() {
@@ -207,7 +230,10 @@ async function patchOpencodeJson(targetDir, installMode, action = "install") {
         ? { ...existingCommand }
         : {};
     for (const [key, value] of Object.entries(GLOBAL_HERO_COMMANDS)) {
-      if (!(key in commands)) {
+      const existing = commands[key];
+      // Upgrade legacy string entries (pre-schema-fix) to the object form, and
+      // backfill missing entries. Leave user-customised object entries alone.
+      if (existing === undefined || typeof existing === "string") {
         commands[key] = value;
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-hero-workflow",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "OpenCode workflow scaffold encoding Matt Pocock's Essential Skills for AI Coding.",
   "repository": {

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -123,11 +123,43 @@ describe("hero-init global mode (default)", () => {
     expect(parsed.plugin).toContain(PLUGIN_REF);
     expect(parsed.default_agent).toBeUndefined();
     for (const key of HERO_COMMAND_KEYS) {
-      expect(parsed.command[key]).toEqual(expect.any(String));
+      const entry = parsed.command[key];
+      expect(entry).toEqual(expect.any(Object));
+      expect(typeof entry.template).toBe("string");
+      expect(entry.template.length).toBeGreaterThan(0);
     }
 
     expect(existsSync(join(globalRoot, ".opencode", "commands"))).toBe(false);
     expect(existsSync(join(globalRoot, ".opencode", "commands", "grill.md"))).toBe(false);
+  });
+
+  test("upgrades legacy string-form hero:* command entries to object form", () => {
+    const globalRoot = join(homeDir, ".config", "opencode");
+    const opencodePath = join(globalRoot, "opencode.json");
+    mkdirSync(globalRoot, { recursive: true });
+    writeFileSync(
+      opencodePath,
+      JSON.stringify(
+        {
+          command: {
+            "hero:grill-me": "old string-form prompt that broke the schema",
+            "custom:hello": "say hi",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    runInit([...modelFlags()], { homeDir, cwd: projectDir });
+
+    const parsed = readJson(opencodePath);
+    // Legacy string entry should be replaced with the proper object form.
+    expect(typeof parsed.command["hero:grill-me"]).toBe("object");
+    expect(typeof parsed.command["hero:grill-me"].template).toBe("string");
+    // Unrelated user entries are preserved as-is, even if they are strings.
+    expect(parsed.command["custom:hello"]).toBe("say hi");
   });
 
   test("merges opencode.json without clobbering unrelated keys or default_agent", () => {
@@ -156,7 +188,9 @@ describe("hero-init global mode (default)", () => {
     expect(parsed.default_agent).toBe("code");
     expect(parsed.command["custom:hello"]).toBe("say hi");
     for (const key of HERO_COMMAND_KEYS) {
-      expect(parsed.command[key]).toEqual(expect.any(String));
+      const entry = parsed.command[key];
+      expect(entry).toEqual(expect.any(Object));
+      expect(typeof entry.template).toBe("string");
     }
     expect(parsed.plugin).toContain("other-plugin");
     expect(parsed.plugin).toContain(PLUGIN_REF);


### PR DESCRIPTION
## Summary
- `bin/init.js` was writing each `hero:*` command as a bare string into `opencode.json`, but the [opencode commands schema](https://opencode.ai/docs/commands/) requires an object with at minimum a `template` field.
- Result: opencode refused to load the user's config with `Expected object, got "..." command.hero:*`, blocking the TUI from starting.

## Changes
- Convert `GLOBAL_HERO_COMMANDS` entries to `{ description, template }` objects that conform to the schema.
- Auto-heal existing broken installs: the patcher now overwrites legacy string-form `hero:*` entries on the next `hero-init` run, while leaving user-customised object entries alone.
- Update existing tests to assert the object schema.
- Add a new test `upgrades legacy string-form hero:* command entries to object form` covering the auto-heal path.
- Bump version to `0.2.2`.

## Test plan
- `bun test tests/init.test.ts` -> 12 pass / 0 fail.
- Manually verified the corrected `opencode.json` parses and opencode launches.