### PR TITLE
ci: auto-create GitHub Release after npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,10 +6,10 @@ on:
       - "v*"
 
 # id-token: write is required for npm trusted publishing (OIDC).
-# contents: read is the default minimum after id-token is requested.
+# contents: write is required to create the GitHub Release after publish.
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   publish:
@@ -71,3 +71,15 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Idempotent so reruns of a partially-failed publish don't error out;
+      # --generate-notes auto-populates from PRs/commits since the last tag.
+      - name: create GitHub Release
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "release $GITHUB_REF_NAME already exists, skipping"
+          else
+            gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes --title "$GITHUB_REF_NAME"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- The Publish workflow only ran `npm publish` and never created a GitHub Release, so npm and the Releases page could drift apart (v0.2.4 published to npm as `latest`, but v0.2.3 stayed pinned as the Latest Release on GitHub until someone filed v0.2.4 by hand).
- Adds a final step that calls `gh release create $GITHUB_REF_NAME --verify-tag --generate-notes` after `npm publish` succeeds.
- Bumps `permissions.contents` from `read` to `write` so the step can create the release.

The new step is idempotent: if a partially-failed publish run is retried after a manual release was filed, the step detects the existing release and skips, instead of failing the rerun.

`--generate-notes` autopopulates release notes from merged PR titles and commits since the previous tag, so future tags don't need babysitting; you can still edit notes in the UI afterward.

## Test plan

- [ ] CI on this branch goes green (no logic exercised — only `permissions:` block and a step are added).
- [ ] On the next `vX.Y.Z` tag push, the Publish run creates the GitHub Release automatically and the Releases page shows the new tag as Latest.
- [ ] If the publish run is manually re-run after a release already exists, the step prints "release ... already exists, skipping" and exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)